### PR TITLE
Dockerfile: overwrite any existing symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN mkdir -p /app/gitea \
     && curl -sLo /app/gitea/gitea.asc https://github.com/go-gitea/gitea/releases/download/v${BUILD_VERSION}/gitea-${BUILD_VERSION}-linux-arm-6.asc \
     && gpg --verify /app/gitea/gitea.asc /app/gitea/gitea \
     && chmod 0755 /app/gitea/gitea \
-    && ln -s /app/gitea/gitea /usr/local/bin/gitea \
+    && ln -fns /app/gitea/gitea /usr/local/bin/gitea \
     && rm -rf /root/.gnupg
 
 # Delete build dependencies


### PR DESCRIPTION

This proposed fix only aims to fix an error that occurs when creating a symbolic link during the build.
 
```
$ docker build . --build-arg BUILD_VERSION=1.16.4

Step 23/26 : RUN mkdir -p /app/gitea     && gpg --keyserver keyserver.ubuntu.com --recv 7C9E68152594688862D62AF62D9AE806EC1592E2     && curl -sLo /app/gitea/gitea https://github.com/go-gitea/gitea/releases/download/v${BUILD_VERSION}/gitea-${BUILD_VERSION}-linux-arm-6     && curl -sLo /app/gitea/gitea.asc https://github.com/go-gitea/gitea/releases/download/v${BUILD_VERSION}/gitea-${BUILD_VERSION}-linux-arm-6.asc     && gpg --verify /app/gitea/gitea.asc /app/gitea/gitea     && chmod 0755 /app/gitea/gitea     && ln -s /app/gitea/gitea /usr/local/bin/gitea     && rm -rf /root/.gnupg
 ---> Running in 3218eb968776
[...]
ln: /usr/local/bin/gitea: File exists
The command '/bin/sh -c mkdir -p /app/gitea     && gpg --keyserver keyserver.ubuntu.com --recv 7C9E68152594688862D62AF62D9AE806EC1592E2     && curl -sLo /app/gitea/gitea https://github.com/go-gitea/gitea/releases/download/v${BUILD_VERSION}/gitea-${BUILD_VERSION}-linux-arm-6     && curl -sLo /app/gitea/gitea.asc https://github.com/go-gitea/gitea/releases/download/v${BUILD_VERSION}/gitea-${BUILD_VERSION}-linux-arm-6.asc     && gpg --verify /app/gitea/gitea.asc /app/gitea/gitea     && chmod 0755 /app/gitea/gitea     && ln -s /app/gitea/gitea /usr/local/bin/gitea     && rm -rf /root/.gnupg' returned a non-zero code: 1

```

After the proposed patch, the command is successful. I have not looked into the reason why the file existed already.

My setup, if needed:
```
$ uname -ar
Linux ubuntu 5.13.0-1022-raspi #24-Ubuntu SMP PREEMPT Wed Mar 16 07:22:00 UTC 2022 armv7l armv7l armv7l GNU/Linux
```

Anyway, thanks for this Dockerfile, it has been very helpful!